### PR TITLE
DBAL Types always need to know how to handle null

### DIFF
--- a/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyValueObjectDBALType.php
+++ b/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyValueObjectDBALType.php
@@ -12,8 +12,12 @@ final class MyValueObjectDBALType extends StringType
         return 'testmodule_mytestentity_myvalueobject';
     }
 
-    public function convertToPHPValue($myValueObjectDBALType, AbstractPlatform $platform): MyValueObject
+    public function convertToPHPValue($myValueObjectDBALType, AbstractPlatform $platform): ?MyValueObject
     {
+        if ($myValueObjectDBALType === null) {
+            return null;
+        }
+
         return new MyValueObject($myValueObjectDBALType);
     }
 

--- a/features/generate/domain/resources/php71/Standalone/MyValueObjectDBALType.php
+++ b/features/generate/domain/resources/php71/Standalone/MyValueObjectDBALType.php
@@ -12,8 +12,12 @@ final class MyValueObjectDBALType extends StringType
         return 'myvalueobject';
     }
 
-    public function convertToPHPValue($myValueObjectDBALType, AbstractPlatform $platform): MyValueObject
+    public function convertToPHPValue($myValueObjectDBALType, AbstractPlatform $platform): ?MyValueObject
     {
+        if ($myValueObjectDBALType === null) {
+            return null;
+        }
+
         return new MyValueObject($myValueObjectDBALType);
     }
 

--- a/src/Domain/ValueObject/ValueObjectDBALType.php71.php.twig
+++ b/src/Domain/ValueObject/ValueObjectDBALType.php71.php.twig
@@ -12,8 +12,12 @@ final class {{ class.className.name }} extends StringType
         return '{{ class.name }}';
     }
 
-    public function convertToPHPValue(${{ class.className.forParameter }}, AbstractPlatform $platform): {{ class.valueObjectClassName.name }}
+    public function convertToPHPValue(${{ class.className.forParameter }}, AbstractPlatform $platform): ?{{ class.valueObjectClassName.name }}
     {
+        if (${{ class.className.forParameter }} === null) {
+            return null;
+        }
+
         return new {{ class.valueObjectClassName.name }}(${{ class.className.forParameter }});
     }
 


### PR DESCRIPTION
This is because queries that don't filter on the dbal type will have null as value